### PR TITLE
Improve conversation flow transitions

### DIFF
--- a/res/style.css
+++ b/res/style.css
@@ -57,6 +57,117 @@ html, body {
 
 .conversation {
   width: min(820px, 92vw);
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  position: relative;
+}
+
+.bg-svg {
+  position: fixed;
+  inset: 0;
+  opacity: 0.18;
+  z-index: 0;
+}
+
+.bg-svg object { width: 100%; height: 100%; }
+
+.screen {
+  position: relative;
+  padding: 18px 18px 20px;
+  border-radius: 16px;
+  border: 1px solid var(--border);
+  background: rgba(255,255,255,0.04);
+  box-shadow: 0 12px 40px rgba(0,0,0,0.28);
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  transition: opacity 1.6s ease, transform 1.6s ease;
+}
+
+.screen--fading {
+  opacity: 0;
+  transform: translateY(-14px);
+}
+
+.message {
+  margin: 0;
+  line-height: 1.5;
+  font-size: 1.05rem;
+  opacity: 0;
+  animation: messageFade 1.4s ease forwards;
+}
+
+.message.typing {
+  opacity: 0.6;
+  animation-duration: 0.6s;
+}
+
+@keyframes messageFade {
+  from { opacity: 0; transform: translateY(8px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+.message-input {
+  width: 100%;
+  padding: 11px 12px;
+  border-radius: 12px;
+  border: 1px solid var(--border);
+  background: rgba(255,255,255,0.08);
+  color: #fff;
+  font-size: 1rem;
+  outline: none;
+  opacity: 0;
+  animation: messageFade 1s ease forwards;
+}
+
+.message-input:focus {
+  border-color: color-mix(in oklab, var(--accent), white 20%);
+  box-shadow: 0 0 0 2px rgba(91, 140, 255, 0.25);
+}
+
+.choice-row {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+  margin-top: 6px;
+}
+
+.choice-button {
+  padding: 10px 12px;
+  border-radius: 12px;
+  border: 1px solid var(--border);
+  background: rgba(255,255,255,0.08);
+  color: #fff;
+  cursor: pointer;
+  min-width: 44px;
+  opacity: 0;
+  animation: messageFade 0.8s ease forwards;
+}
+
+.choice-button:disabled { opacity: 0.5; cursor: not-allowed; }
+.choice-button:hover:not(:disabled) { filter: brightness(1.08); }
+
+.toast {
+  position: fixed;
+  bottom: 18px;
+  left: 50%;
+  transform: translate(-50%, 30px);
+  background: rgba(0,0,0,0.8);
+  border: 1px solid var(--border);
+  color: #fff;
+  padding: 12px 16px;
+  border-radius: 12px;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.3s ease, transform 0.3s ease;
+  z-index: 10000;
+}
+
+.toast.show {
+  opacity: 1;
+  transform: translate(-50%, 0);
+}
 }
 
 /* Buttons */


### PR DESCRIPTION
## Summary
- add fade-in animation styling for messages, inputs, and choices so conversation flows stack naturally
- adjust screen transitions to hold for 5 seconds and keep prompts on the same page before fading to the next
- surface a toast message when a journal entry already exists for the current day

## Testing
- Not run (not requested).


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6939e19f6124832db83e19b115da4fc3)